### PR TITLE
Fixing and expanding

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,15 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+numpy = "*"
+matplotlib = "*"
+numba = "*"
+tqdm = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "2.7"

--- a/python_vs_c/std.cpp
+++ b/python_vs_c/std.cpp
@@ -1,4 +1,3 @@
-#include <Python/Python.h>
 #include <vector>
 #include <numeric>
 #include <iterator>

--- a/python_vs_c/stdtest.py
+++ b/python_vs_c/stdtest.py
@@ -7,6 +7,7 @@ import timeit
 import math
 from matplotlib import pyplot as plt
 import std
+import numba
 
 from tqdm import tqdm as progress_bar
 
@@ -20,31 +21,52 @@ def standard_deviation(lst):
     variance = sum([(value - m) ** 2 for value in lst])
     return math.sqrt(variance / len(lst))
 
+@numba.jit(numba.double(numba.double[:]), nopython=True)
+def numba_standard_deviation(lst):
+    return np.std(lst)
+
+@numba.jit(numba.double(numba.double[:]), nopython=True)
+def numba_longer_standard_deviation(lst):
+    m = np.mean(lst)
+    variance = np.sum((lst - m) ** 2)
+    return math.sqrt(variance / len(lst))
+
 
 if __name__ == '__main__':
-    for low in (True, False):
+    fig, axs = plt.subplots(1,2,figsize=(14,6))
+
+    for ax in axs:
+        low = ax is axs[0]
+
         lens = range(10, 300, 10) if low else range(1000,30000,1000)
         py_time = []
         np_time = []
+        numba1_time = []
+        numba2_time = []
         c_time = []
 
         for l in progress_bar(lens, desc = 'Lower' if low else 'Upper'):
-            rands = [random.random() for _ in range(0, l)]
+            rands = [random.random() for _ in range(l)]
             numpy_rands = np.array(rands)
+
+            numba1_time.append(timeit.timeit(lambda: numba_standard_deviation(numpy_rands), number=1000))
+            numba2_time.append(timeit.timeit(lambda: numba_longer_standard_deviation(numpy_rands), number=1000))
+            np_time.append(timeit.timeit(lambda: np.std(numpy_rands), number=1000))
+            c_time.append(timeit.timeit(lambda: std.standard_dev(rands), number=1000))
             if low:
-                py_time = np.append(py_time, timeit.timeit(lambda: standard_deviation(rands), number=10000))
-            np_time = np.append(np_time, timeit.timeit(lambda: np.std(numpy_rands), number=10000))
-            c_time = np.append(c_time, timeit.timeit(lambda: std.standard_dev(rands), number=10000))
+                py_time.append(timeit.timeit(lambda: standard_deviation(rands), number=1000))
 
-        plt.figure()
 
+        ax.plot(lens, c_time, label='C++')
+        ax.plot(lens, np_time, label='Numpy')
+        ax.plot(lens, numba1_time, label='Numba np.std')
+        ax.plot(lens, numba2_time, label='Numba longer')
         if low:
-            plt.plot(lens, py_time, label='Python')
-        plt.plot(lens, np_time, label='Numpy')
-        plt.plot(lens, c_time, label='C++')
+            ax.plot(lens, py_time, label='Python')
 
-        plt.legend(loc='best')
-        plt.ylabel('Time (Seconds)')
-        plt.xlabel('Number of Elements')
-        plt.title('Comparison of std dev performance')
-        plt.savefig('lower_results.png' if low else 'upper_results.png')
+        ax.legend(loc='best')
+        ax.set_ylabel('Time (Seconds)')
+        ax.set_xlabel('Number of Elements')
+        ax.set_title('Comparison of std dev performance')
+
+    plt.savefig('results.png')

--- a/python_vs_c/stdtest.py
+++ b/python_vs_c/stdtest.py
@@ -1,10 +1,14 @@
+import matplotlib
+matplotlib.use('Agg')
+
 import numpy as np
 import random
 import timeit
 import math
-import pandas as pd
 from matplotlib import pyplot as plt
 import std
+
+from tqdm import tqdm as progress_bar
 
 
 def mean(lst):
@@ -18,25 +22,29 @@ def standard_deviation(lst):
 
 
 if __name__ == '__main__':
+    for low in (True, False):
+        lens = range(10, 300, 10) if low else range(1000,30000,1000)
+        py_time = []
+        np_time = []
+        c_time = []
 
-    lens = range(10, 300, 10)
-    py_time = []
-    np_time = []
-    c_time = []
+        for l in progress_bar(lens, desc = 'Lower' if low else 'Upper'):
+            rands = [random.random() for _ in range(0, l)]
+            numpy_rands = np.array(rands)
+            if low:
+                py_time = np.append(py_time, timeit.timeit(lambda: standard_deviation(rands), number=10000))
+            np_time = np.append(np_time, timeit.timeit(lambda: np.std(numpy_rands), number=10000))
+            c_time = np.append(c_time, timeit.timeit(lambda: std.standard_dev(rands), number=10000))
 
-    for l in lens:
-        rands = [random.random() for _ in range(0, l)]
-        numpy_rands = np.array(rands)
-        py_time = np.append(py_time, timeit.timeit(lambda: standard_deviation(rands), number=10000))
-        np_time = np.append(np_time, timeit.timeit(lambda: np.std(numpy_rands), number=10000))
-        c_time = np.append(c_time, timeit.timeit(lambda: std.standard_dev(rands), number=10000))
-    data = np.array([np.transpose(py_time), np.transpose(np_time), np.transpose(c_time)])
+        plt.figure()
 
-    df = pd.DataFrame(data.transpose(), index=lens, columns=['Python', 'Numpy', 'C++'])
-    plt.figure()
-    df.plot()
-    plt.legend(loc='best')
-    plt.ylabel('Time (Seconds)')
-    plt.xlabel('Number of Elements')
-    plt.title('10k Runs of Standard Deviation')
-    plt.show()
+        if low:
+            plt.plot(lens, py_time, label='Python')
+        plt.plot(lens, np_time, label='Numpy')
+        plt.plot(lens, c_time, label='C++')
+
+        plt.legend(loc='best')
+        plt.ylabel('Time (Seconds)')
+        plt.xlabel('Number of Elements')
+        plt.title('Comparison of std dev performance')
+        plt.savefig('lower_results.png' if low else 'upper_results.png')


### PR DESCRIPTION
This has a few bugs (incorrect `#include <Python/Python.h>` and correct `#include <Python.h>` both present), and has been extended to produce both plots in the article, and to add a Numba example.

Here are my results:

![results](https://user-images.githubusercontent.com/4616906/44146008-ffb744c8-a08d-11e8-9e2c-95eea9c3b974.png)

The best version is the numba one line function:

```python
@numba.jit(numba.double(numba.double[:]), nopython=True)
def numba_standard_deviation(lst):
    return np.std(lst)
```

Which is fastest for 10+ elements.

Someone has also pointed out that if you had an array of value that needed stddev on them, something like `data.reshape(-1, 25).std(axis=1)` would do nicely.

By the way, the C extension does not support Python 3.

PS: I changed from 10,000 runs to 1,000 to make testing easier, it could be changed back.